### PR TITLE
Домашнее задание уроку 1: переделка сетевого чата под Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Spring1
-GeekBrins Spring 1 course homeworks
+GeekBrains Spring 1 course homeworks

--- a/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/ChatClientConfig.java
+++ b/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/ChatClientConfig.java
@@ -1,0 +1,56 @@
+package com.mvnikitin.nettychat.client;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import javafx.fxml.FXMLLoader;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("com.mvnikitin.nettychat.client")
+public class ChatClientConfig {
+
+    @Bean(name="fxmlLoader")
+    public FXMLLoader fxmlLoader(@Value("/client.fxml") String fxml) {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource(fxml));
+        return loader;
+    }
+
+    @Bean(name="network")
+    public Network network(@Value("localhost") String host,
+                           @Value("8189") int port) {
+        Network network = new Network(host, port);
+        return network;
+    }
+
+    @Bean(name="workerGroup")
+    public EventLoopGroup workerGroup() {
+        return new NioEventLoopGroup();
+    }
+
+    @Bean(name="bootstrap")
+    public Bootstrap bootstrap() {
+        return new Bootstrap();
+    }
+
+    @Bean(name="encoder")
+    public StringEncoder encoder() {
+        return new StringEncoder();
+    }
+
+    @Bean(name="decoder")
+    public StringDecoder decoder() {
+        return new StringDecoder();
+    }
+
+    @Bean(name="handler")
+    public ClientHandler handler() {
+        return new ClientHandler();
+    }
+}

--- a/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/ClientHandler.java
+++ b/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/ClientHandler.java
@@ -2,14 +2,12 @@ package com.mvnikitin.nettychat.client;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ClientHandler extends SimpleChannelInboundHandler<String>{
 
     private Callback onMessageReceivedCallback;
-
-    public ClientHandler(Callback onMessageReceivedCallback) {
-        this.onMessageReceivedCallback = onMessageReceivedCallback;
-    }
 
     @Override
     protected void channelRead0(
@@ -18,5 +16,9 @@ public class ClientHandler extends SimpleChannelInboundHandler<String>{
         if(onMessageReceivedCallback != null) {
             onMessageReceivedCallback.callback(s);
         }
+    }
+
+    public void setOnMessageReceivedCallback(Callback onMessageReceivedCallback) {
+        this.onMessageReceivedCallback = onMessageReceivedCallback;
     }
 }

--- a/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Controller.java
+++ b/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Controller.java
@@ -21,7 +21,15 @@ public class Controller implements Initializable {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
-        network = new Network((args) -> {
+//        network = new Network((args) -> {
+//            textArea.appendText((String)args[0]);
+//            textArea.appendText("\n");
+//        });
+    }
+
+    public void setupNetwork(Network network) {
+        this.network = network;
+        network.init((args) -> {
             textArea.appendText((String)args[0]);
             textArea.appendText("\n");
         });
@@ -33,7 +41,7 @@ public class Controller implements Initializable {
         msgField.requestFocus();
     }
 
-    public void exit(ActionEvent actionEvent) {
+    public void exit() {
         network.close();
         Platform.exit();
     }

--- a/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Main.java
+++ b/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Main.java
@@ -5,11 +5,21 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class Main extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception{
-        Parent root = FXMLLoader.load(getClass().getResource("/client.fxml"));
+        ApplicationContext context =
+                new AnnotationConfigApplicationContext(ChatClientConfig.class);
+        FXMLLoader loader = context.getBean("fxmlLoader", FXMLLoader.class);
+        Network network = context.getBean("network", Network.class);
+
+        Parent root = loader.load();
+        Controller controller = loader.getController();
+        controller.setupNetwork(network);
+        primaryStage.setOnCloseRequest(event -> controller.exit());
         primaryStage.setTitle("Netty Chat Client");
         primaryStage.setScene(new Scene(root, 500, 400));
         primaryStage.show();

--- a/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Network.java
+++ b/lesson1/netty-chat-client/src/main/java/com/mvnikitin/nettychat/client/Network.java
@@ -7,38 +7,52 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Network {
-    private static final String HOST = "localhost";
-    private static final int PORT = 8189;
+    private String host;
+    private int port;
     private SocketChannel channel;
 
-    public Network(Callback messageReceived) {
-        Thread t = new Thread(() -> {
-            EventLoopGroup workerGroup = new NioEventLoopGroup();
+    @Autowired
+    private EventLoopGroup workerGroup;
+    @Autowired
+    private Bootstrap bootstrap;
+    @Autowired
+    private StringDecoder decoder;
+    @Autowired
+    private StringEncoder encoder;
+    @Autowired
+    private ClientHandler handler;
+
+    public Network(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public void init(Callback messageReceived) {
+        handler.setOnMessageReceivedCallback(messageReceived);
+        new Thread(() -> {
             try {
-                Bootstrap b = new Bootstrap();
-                b.group(workerGroup)
+                bootstrap.group(workerGroup)
                         .channel(NioSocketChannel.class)
                         .handler(new ChannelInitializer<SocketChannel>() {
                             @Override
                             public void initChannel(SocketChannel ch) throws Exception {
                                 channel = ch;
-                                ch.pipeline().addLast(new StringDecoder(), new StringEncoder(), new ClientHandler(messageReceived));
+                                ch.pipeline().addLast(decoder, encoder, handler);
                             }
                         });
-                ChannelFuture f = b.connect(HOST, PORT).sync();
+                ChannelFuture f = bootstrap.connect(host, port).sync();
                 f.channel().closeFuture().sync();
             } catch (InterruptedException e) {
                 e.printStackTrace();
             } finally {
                 workerGroup.shutdownGracefully();
             }
-        });
-
-        t.setDaemon(true);
-        t.start();
-
+        }).start();
     }
 
     public void sendMessage(String msg) {
@@ -46,7 +60,6 @@ public class Network {
     }
 
     public void close() {
-        //channel.writeAndFlush("/disconnect");
         channel.close();
     }
 }

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServer.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServer.java
@@ -1,0 +1,15 @@
+package com.mvnikitin.nettychat.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+
+public interface ChatServer {
+    void start();
+    void setBossGroup(EventLoopGroup bossGroup);
+    void setWorkerGroup(EventLoopGroup workerGroup);
+    void setBootstrap(ServerBootstrap bootstrap);
+    void setEncoder(StringEncoder encoder);
+    void setDecoder(StringDecoder decoder);
+}

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServer.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServer.java
@@ -10,6 +10,6 @@ public interface ChatServer {
     void setBossGroup(EventLoopGroup bossGroup);
     void setWorkerGroup(EventLoopGroup workerGroup);
     void setBootstrap(ServerBootstrap bootstrap);
-    void setEncoder(StringEncoder encoder);
-    void setDecoder(StringDecoder decoder);
+//    void setEncoder(StringEncoder encoder);
+//    void setDecoder(StringDecoder decoder);
 }

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerChannelInitializer.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerChannelInitializer.java
@@ -1,0 +1,32 @@
+package com.mvnikitin.nettychat.server;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatServerChannelInitializer
+        extends ChannelInitializer<SocketChannel> {
+    @Autowired
+    private StringDecoder decoder;
+    @Autowired
+    private StringEncoder encoder;
+
+    @Lookup
+    public MainHandler createMainHandler() {
+        return null;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel socketChannel) throws Exception {
+        /***************************************
+         * НЕ РАБОТАЕТ :(
+         **************************************/
+        MainHandler handler = createMainHandler();
+        socketChannel.pipeline().addLast(decoder, encoder, handler);
+    }
+}

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerChannelInitializer.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerChannelInitializer.java
@@ -23,9 +23,6 @@ public class ChatServerChannelInitializer
 
     @Override
     protected void initChannel(SocketChannel socketChannel) throws Exception {
-        /***************************************
-         * НЕ РАБОТАЕТ :(
-         **************************************/
         MainHandler handler = createMainHandler();
         socketChannel.pipeline().addLast(decoder, encoder, handler);
     }

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerConfig.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerConfig.java
@@ -1,0 +1,52 @@
+package com.mvnikitin.nettychat.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("com.mvnikitin.nettychat.server")
+public class ChatServerConfig {
+    @Bean(name="chatServer")
+    public ChatServer chatServer(
+            @Value("8189") int port) {
+        ChatServer server = new ChatServerImpl(port);
+        return server;
+    }
+
+    @Bean(name="bossGroup")
+    public EventLoopGroup bossGroup(@Value("1") int threads) {
+        return new NioEventLoopGroup(threads);
+    }
+
+    @Bean(name="workerGroup")
+    public EventLoopGroup workerGroup() {
+        return new NioEventLoopGroup();
+    }
+
+    @Bean(name="bootstrap")
+    public ServerBootstrap bootstrap() {
+        return new ServerBootstrap();
+    }
+
+    @Bean(name="encoder")
+    public StringEncoder encoder() {
+        return new StringEncoder();
+    }
+
+    @Bean(name="decoder")
+    public StringDecoder decoder() {
+        return new StringDecoder();
+    }
+
+//    @Bean(name="channelInitializer")
+//    public ChatServerChannelInitializer channelInitializer() {
+//        return new ChatServerChannelInitializer();
+//    }
+}

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerConfig.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerConfig.java
@@ -44,9 +44,4 @@ public class ChatServerConfig {
     public StringDecoder decoder() {
         return new StringDecoder();
     }
-
-//    @Bean(name="channelInitializer")
-//    public ChatServerChannelInitializer channelInitializer() {
-//        return new ChatServerChannelInitializer();
-//    }
 }

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerImpl.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerImpl.java
@@ -1,0 +1,90 @@
+package com.mvnikitin.nettychat.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component("chatServer")
+public class ChatServerImpl implements ChatServer {
+    private int port;
+
+    @Autowired
+    ApplicationContext context;
+
+    @Autowired
+    private EventLoopGroup bossGroup;
+    @Autowired
+    private EventLoopGroup workerGroup;
+    @Autowired
+    private ServerBootstrap bootstrap;
+    @Autowired
+    private StringDecoder decoder;
+    @Autowired
+    private StringEncoder encoder;
+//    @Autowired
+//    private ChatServerChannelInitializer channelInitializer;
+
+    public ChatServerImpl(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public void setBossGroup(EventLoopGroup bossGroup) {
+        this.bossGroup = bossGroup;
+    }
+
+    @Override
+    public void setWorkerGroup(EventLoopGroup workerGroup) {
+        this.workerGroup = workerGroup;
+    }
+
+    @Override
+    public void setBootstrap(ServerBootstrap bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    @Override
+    public void setDecoder(StringDecoder decoder) {
+        this.decoder = decoder;
+    }
+
+    @Override
+    public void setEncoder(StringEncoder encoder) {
+        this.encoder = encoder;
+    }
+
+    @Override
+    public void start() {
+        try {
+            bootstrap.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+//                    .childHandler(channelInitializer);
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel socketChannel)
+                                throws Exception {
+                            //socketChannel.pipeline().addLast(decoder, encoder, new MainHandler());
+                            MainHandler handler = context.getBean(MainHandler.class);
+                            socketChannel.pipeline().addLast(decoder, encoder, handler);
+                        }
+                    });
+            ChannelFuture future = bootstrap.bind(port).sync();
+            System.out.println("Сервер запущен!");
+            future.channel().closeFuture().sync();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerImpl.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ChatServerImpl.java
@@ -18,20 +18,17 @@ public class ChatServerImpl implements ChatServer {
     private int port;
 
     @Autowired
-    ApplicationContext context;
-
-    @Autowired
     private EventLoopGroup bossGroup;
     @Autowired
     private EventLoopGroup workerGroup;
     @Autowired
     private ServerBootstrap bootstrap;
-    @Autowired
-    private StringDecoder decoder;
-    @Autowired
-    private StringEncoder encoder;
 //    @Autowired
-//    private ChatServerChannelInitializer channelInitializer;
+//    private StringDecoder decoder;
+//    @Autowired
+//    private StringEncoder encoder;
+    @Autowired
+    private ChatServerChannelInitializer channelInitializer;
 
     public ChatServerImpl(int port) {
         this.port = port;
@@ -52,31 +49,29 @@ public class ChatServerImpl implements ChatServer {
         this.bootstrap = bootstrap;
     }
 
-    @Override
-    public void setDecoder(StringDecoder decoder) {
-        this.decoder = decoder;
-    }
-
-    @Override
-    public void setEncoder(StringEncoder encoder) {
-        this.encoder = encoder;
-    }
+//    @Override
+//    public void setDecoder(StringDecoder decoder) {
+//        this.decoder = decoder;
+//    }
+//
+//    @Override
+//    public void setEncoder(StringEncoder encoder) {
+//        this.encoder = encoder;
+//    }
 
     @Override
     public void start() {
         try {
             bootstrap.group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
-//                    .childHandler(channelInitializer);
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        protected void initChannel(SocketChannel socketChannel)
-                                throws Exception {
-                            //socketChannel.pipeline().addLast(decoder, encoder, new MainHandler());
-                            MainHandler handler = context.getBean(MainHandler.class);
-                            socketChannel.pipeline().addLast(decoder, encoder, handler);
-                        }
-                    });
+                    .childHandler(channelInitializer);
+//                    .childHandler(new ChannelInitializer<SocketChannel>() {
+//                        @Override
+//                        protected void initChannel(SocketChannel socketChannel)
+//                                throws Exception {
+//                            //socketChannel.pipeline().addLast(decoder, encoder, new MainHandler());
+//                        }
+//                    });
             ChannelFuture future = bootstrap.bind(port).sync();
             System.out.println("Сервер запущен!");
             future.channel().closeFuture().sync();

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/MainHandler.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/MainHandler.java
@@ -3,10 +3,14 @@ package com.mvnikitin.nettychat.server;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Component
+@Scope("prototype")
 public class MainHandler extends SimpleChannelInboundHandler<String> {
     private static final List<Channel> channels = new ArrayList<>();
     private static int newClientIndex = 1;
@@ -14,7 +18,7 @@ public class MainHandler extends SimpleChannelInboundHandler<String> {
 
     @Override
     public void channelActive(final ChannelHandlerContext ctx) {
-        System.out.println("Клиент подключился - " + ctx);
+        System.out.println("Клиент подключился: " + ctx);
         channels.add(ctx.channel());
         clientName = "Клиент #" + newClientIndex;
         newClientIndex++;
@@ -45,7 +49,7 @@ public class MainHandler extends SimpleChannelInboundHandler<String> {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        System.out.println("Клиент отвалился - " + ctx);
+        System.out.println("Клиент " + clientName + " покинул чат");
         channels.remove(ctx.channel());
         broadcastMessage("SERVER", "Клиент " + clientName + " покинул чат");
         super.channelInactive(ctx);

--- a/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ServerApp.java
+++ b/lesson1/netty-chat-server/src/main/java/com/mvnikitin/nettychat/server/ServerApp.java
@@ -1,39 +1,16 @@
 package com.mvnikitin.nettychat.server;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.codec.string.StringDecoder;
-import io.netty.handler.codec.string.StringEncoder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class ServerApp {
-    private static final int PORT = 8189;
-
-    public static void main(String[] args) throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
-        try {
-            ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
-                    .channel(NioServerSocketChannel.class)
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        public void initChannel(SocketChannel ch) throws Exception {
-                            ChannelPipeline p = ch.pipeline();
-                            p.addLast(new StringDecoder(), new StringEncoder(), new MainHandler());
-                        }
-                    });
-            ChannelFuture future = b.bind(PORT).sync();
-            System.out.println("Сервер запущен, ожидаем клиентов...");
-            future.channel().closeFuture().sync();
-        } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
-        }
+    public static void main(String[] args) {
+//        ApplicationContext context =
+//                new ClassPathXmlApplicationContext("chatserver-config.xml");
+        ApplicationContext context =
+                new AnnotationConfigApplicationContext(ChatServerConfig.class);
+        ChatServer server = context.getBean("chatServer", ChatServer.class);
+        server.start();
     }
 }

--- a/lesson1/netty-chat-server/src/main/resources/chatserver-config.xml
+++ b/lesson1/netty-chat-server/src/main/resources/chatserver-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation = "http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="chatServer" class="com.mvnikitin.nettychat.server.ChatServerImpl">
+        <constructor-arg value="8189"/>
+        <property name="bossGroup">
+            <ref bean="bossGroup"/>
+        </property>
+        <property name="workerGroup">
+            <ref bean="workerGroup"/>
+        </property>
+        <property name="bootstrap">
+            <ref bean="bootstrap"/>
+        </property>
+        <property name="encoder">
+            <ref bean="encoder"/>
+        </property>
+        <property name="decoder">
+            <ref bean="decoder"/>
+        </property>
+    </bean>
+
+    <bean id="bossGroup" class="io.netty.channel.nio.NioEventLoopGroup">
+        <constructor-arg value="1"/>
+    </bean>
+    <bean id="workerGroup" class="io.netty.channel.nio.NioEventLoopGroup"/>
+    <bean id="bootstrap" class="io.netty.bootstrap.ServerBootstrap"/>
+    <bean id="encoder" class="io.netty.handler.codec.string.StringEncoder"/>
+    <bean id="decoder" class="io.netty.handler.codec.string.StringDecoder"/>
+
+</beans>


### PR DESCRIPTION
Домашнее задание уроку 1: переделан сетевой чат netty так, что используются по максимуму бины Spring. Бины сервера создаются двумя способами (XML и JavaConfig), клиент - только JavaConfig. Не получилось создавать бины prototype аннотацией Lookup.